### PR TITLE
Composeで天気を表示する Issue#13

### DIFF
--- a/app/src/main/java/jp/co/yumemi/droidtraining/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/WeatherInfoData.kt
@@ -6,8 +6,21 @@ import androidx.annotation.DrawableRes
  * TODO:正式な形にする
  */
 data class WeatherInfoData(
-    @DrawableRes val icon: Int,
     val weather: String,
     val lowestTemperature: Short,
     val highestTemperature: Short
-)
+){
+    companion object {
+        private val ICONS: Map<String, Int> = mapOf(
+            "sunny" to R.drawable.sunny,
+            "cloudy" to R.drawable.cloudy,
+            "rainy" to R.drawable.rainy,
+            "snow" to R.drawable.snow
+        )
+    }
+
+    @DrawableRes val icon: Int
+    init {
+        icon = ICONS[weather] ?: throw NullPointerException("無効なweatherです： $weather")
+    }
+}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -22,20 +22,28 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import jp.co.yumemi.api.YumemiWeather
 import jp.co.yumemi.droidtraining.R
 import jp.co.yumemi.droidtraining.WeatherInfoData
 
 
 @Composable
 fun WeatherApp(){
+    val yumemiWeather = YumemiWeather(context = LocalContext.current)
     val weather by remember {
-        mutableStateOf(WeatherInfoData(R.drawable.foo, "foo", 10, 20))
+        mutableStateOf(
+            WeatherInfoData(
+                weather = yumemiWeather.fetchSimpleWeather(),
+                lowestTemperature = 5,
+                highestTemperature = 40)
+        )
     }
 
     BoxWithConstraints(
@@ -117,7 +125,7 @@ fun PreviewWeatherApp(){
 @Composable
 @Preview
 fun PreviewWeatherInfo(){
-    val weather = WeatherInfoData(R.drawable.foo, "foo", 10, 20)
+    val weather = WeatherInfoData( "sunny", 10, 20)
     WeatherInfo(weather = weather)
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,16 +34,16 @@ import jp.co.yumemi.api.YumemiWeather
 import jp.co.yumemi.droidtraining.R
 import jp.co.yumemi.droidtraining.WeatherInfoData
 
-
 @Composable
 fun WeatherApp(){
     val yumemiWeather = YumemiWeather(context = LocalContext.current)
-    val weather by remember {
+    var weatherInfoData by remember {
         mutableStateOf(
             WeatherInfoData(
                 weather = yumemiWeather.fetchSimpleWeather(),
                 lowestTemperature = 5,
-                highestTemperature = 40)
+                highestTemperature = 40
+            )
         )
     }
 
@@ -54,10 +55,17 @@ fun WeatherApp(){
         val width = screenWidth / 2
         Column(modifier = Modifier.width(width)) {
             Spacer(modifier = Modifier.weight(1f))
-            WeatherInfo(weather)
+            WeatherInfo(weatherInfoData)
             ActionButtons(modifier = Modifier
                 .padding(top = 80.dp)
-                .weight(1f)
+                .weight(1f),
+                onReloadClick = {
+                    weatherInfoData = WeatherInfoData(
+                        weather = yumemiWeather.fetchSimpleWeather(),
+                        lowestTemperature = 5,
+                        highestTemperature = 40
+                    )
+                }
             )
         }
     }


### PR DESCRIPTION
## 修正内容
Resolve #13

- YumemiWeatherAPIのfetchSimpleWeaterをもとに天気画像を表示
- Reloadボタンで更新する機能を追加

## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [ ] ぱっとみて違和感がないかチェックしてApproveする
- [x] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
特になし


## スクリーンショット


## 備考
<!--
* マージ先のブランチの設定が正しいか確認してください。
* 動画を添付するときは、GitHubの制限のため、アニメーションGifに変換してください。
-->
