### PR TITLE
天気詳細画面を作成する Issue #33

### DIFF
--- a/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
+++ b/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
@@ -57,7 +57,7 @@ class WeatherAppUiTest {
             get() = _weatherInfoData.asStateFlow()
 
         private val _foreCastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
-        override val foreCastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
+        override val forecastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
             get() = _foreCastWeatherInfoDataList.asStateFlow()
 
         override suspend fun updateWeatherInfoData() {

--- a/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
+++ b/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.junit.Rule
 import org.junit.Test
+import java.time.LocalDateTime
 
 class WeatherAppUiTest {
 
@@ -34,6 +35,7 @@ class WeatherAppUiTest {
         highestTemperature = 20,
         place = "岐阜",
         temperature = 15,
+        dateTime = LocalDateTime.now(),
     )
     private val _updatedWeatherInfoData = WeatherInfoData(
         weather = WeatherType.CLOUDY,
@@ -41,6 +43,7 @@ class WeatherAppUiTest {
         highestTemperature = 15,
         place = "東京",
         temperature = 10,
+        dateTime = LocalDateTime.of(2021, 1, 1, 12, 0),
     )
 
     class FakeWeatherInfoDataRepository(
@@ -116,6 +119,7 @@ class WeatherAppUiTest {
             highestTemperature = 15,
             place = "東京",
             temperature = 10,
+            dateTime = LocalDateTime.of(2021, 1, 1, 12, 0),
         )
 
         composeTestRule.setContent {

--- a/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
+++ b/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
@@ -56,6 +56,10 @@ class WeatherAppUiTest {
         override val weatherInfoData: StateFlow<WeatherInfoData>
             get() = _weatherInfoData.asStateFlow()
 
+        private val _foreCastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
+        override val foreCastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
+            get() = _foreCastWeatherInfoDataList.asStateFlow()
+
         override suspend fun updateWeatherInfoData() {
             if (updateFailCount > 0) {
                 updateFailCount -= 1

--- a/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
+++ b/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
@@ -33,12 +33,14 @@ class WeatherAppUiTest {
         lowestTemperature = 10,
         highestTemperature = 20,
         place = "岐阜",
+        temperature = 15,
     )
     private val _updatedWeatherInfoData = WeatherInfoData(
         weather = WeatherType.CLOUDY,
         lowestTemperature = 5,
         highestTemperature = 15,
         place = "東京",
+        temperature = 10,
     )
 
     class FakeWeatherInfoDataRepository(
@@ -113,6 +115,7 @@ class WeatherAppUiTest {
             lowestTemperature = 5,
             highestTemperature = 15,
             place = "東京",
+            temperature = 10,
         )
 
         composeTestRule.setContent {

--- a/app/src/main/java/jp/co/yumemi/droidtraining/FakeWeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/FakeWeatherMainViewModel.kt
@@ -3,6 +3,7 @@ package jp.co.yumemi.droidtraining
 import androidx.lifecycle.SavedStateHandle
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,6 +23,9 @@ class FakeWeatherMainViewModel(
         fakeWeatherInfoDataRepository,
     ),
     getWeatherInfoDataUseCase = GetWeatherInfoDataUseCase(
+        fakeWeatherInfoDataRepository,
+    ),
+    getForecastWeatherInfoDataUseCase = GetForecastWeatherInfoDataUseCase(
         fakeWeatherInfoDataRepository,
     ),
     savedStateHandle = SavedStateHandle(), // fake(empty)

--- a/app/src/main/java/jp/co/yumemi/droidtraining/FakeWeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/FakeWeatherMainViewModel.kt
@@ -37,7 +37,7 @@ class FakeWeatherInfoDataRepository(
         get() = _weatherInfoData.asStateFlow()
 
     private val _foreCastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
-    override val foreCastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
+    override val forecastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
         get() = _foreCastWeatherInfoDataList.asStateFlow()
 
     override suspend fun updateWeatherInfoData() {

--- a/app/src/main/java/jp/co/yumemi/droidtraining/FakeWeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/FakeWeatherMainViewModel.kt
@@ -36,6 +36,10 @@ class FakeWeatherInfoDataRepository(
     override val weatherInfoData: StateFlow<WeatherInfoData>
         get() = _weatherInfoData.asStateFlow()
 
+    private val _foreCastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
+    override val foreCastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
+        get() = _foreCastWeatherInfoDataList.asStateFlow()
+
     override suspend fun updateWeatherInfoData() {
         _weatherInfoData.value = updatedWeatherInfoData
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/HiltModules.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/HiltModules.kt
@@ -10,6 +10,7 @@ import dagger.hilt.components.SingletonComponent
 import jp.co.yumemi.api.YumemiWeather
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepositoryImpl
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
 import javax.inject.Singleton
@@ -49,5 +50,11 @@ object HiltModules {
     @Singleton
     fun provideGetWeatherInfoDataUseCase(repository: WeatherInfoDataRepository): GetWeatherInfoDataUseCase {
         return GetWeatherInfoDataUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetForecastWeatherInfoDataUseCase(repository: WeatherInfoDataRepository): GetForecastWeatherInfoDataUseCase {
+        return GetForecastWeatherInfoDataUseCase(repository)
     }
 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/WeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/WeatherMainViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ open class WeatherMainViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     val updateWeatherInfoDataUseCase: UpdateWeatherInfoDataUseCase,
     val getWeatherInfoDataUseCase: GetWeatherInfoDataUseCase,
+    val getForecastWeatherInfoDataUseCase: GetForecastWeatherInfoDataUseCase
 ) : ViewModel() {
     private val isShowErrorDialogKey = "isShowErrorDialog"
     private val _isShowErrorDialog = MutableStateFlow(
@@ -26,6 +28,8 @@ open class WeatherMainViewModel @Inject constructor(
     val weatherInfoData = getWeatherInfoDataUseCase()
     private val _updating = MutableStateFlow(false)
     val updating = _updating.asStateFlow()
+
+    val forecastWeatherInfoDataList = getForecastWeatherInfoDataUseCase()
 
     init {
         viewModelScope.launch {

--- a/app/src/main/java/jp/co/yumemi/droidtraining/WeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/WeatherMainViewModel.kt
@@ -17,7 +17,7 @@ open class WeatherMainViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     val updateWeatherInfoDataUseCase: UpdateWeatherInfoDataUseCase,
     val getWeatherInfoDataUseCase: GetWeatherInfoDataUseCase,
-    val getForecastWeatherInfoDataUseCase: GetForecastWeatherInfoDataUseCase
+    val getForecastWeatherInfoDataUseCase: GetForecastWeatherInfoDataUseCase,
 ) : ViewModel() {
     private val isShowErrorDialogKey = "isShowErrorDialog"
     private val _isShowErrorDialog = MutableStateFlow(

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/Route.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/Route.kt
@@ -1,0 +1,6 @@
+package jp.co.yumemi.droidtraining.components
+
+enum class Route {
+    WeatherMain,
+    WeatherDetail,
+}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -81,7 +81,7 @@ fun WeatherApp(
                 )
             }
             composable(Route.WeatherDetail.name) {
-                WeatherAppDetailContent()
+                WeatherAppDetailContent(weatherInfoData = weatherInfoData)
             }
         }
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -42,6 +42,8 @@ fun WeatherApp(
 
     val updating by mainViewModel.updating.collectAsStateWithLifecycle()
 
+    val forecastWeatherInfoDataList by mainViewModel.forecastWeatherInfoDataList.collectAsStateWithLifecycle()
+
     WeatherFetchErrorDialog(
         showDialog = showErrorDialog,
         onDismissRequest = { mainViewModel.closeErrorDialog() },
@@ -82,7 +84,10 @@ fun WeatherApp(
                 )
             }
             composable(Route.WeatherDetail.name) {
-                WeatherAppDetailContent(weatherInfoData = weatherInfoData)
+                WeatherAppDetailContent(
+                    weatherInfoData = weatherInfoData,
+                    forecastWeatherInfoDataList = forecastWeatherInfoDataList
+                )
             }
         }
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -29,6 +29,7 @@ import jp.co.yumemi.droidtraining.WeatherMainViewModel
 import jp.co.yumemi.droidtraining.WeatherType
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.theme.YumemiTheme
+import java.time.LocalDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -102,6 +103,7 @@ fun PreviewWeatherApp() {
             highestTemperature = 40,
             place = "岐阜",
             temperature = 10,
+            dateTime = LocalDateTime.now()
         ),
     )
     YumemiTheme {
@@ -120,6 +122,7 @@ fun DarkPreviewWeatherApp() {
             highestTemperature = 40,
             place = "岐阜",
             temperature = 10,
+            dateTime = LocalDateTime.now()
         ),
     )
     YumemiTheme {
@@ -134,6 +137,7 @@ class WeatherAppPreviewParameterProvider : PreviewParameterProvider<WeatherInfoD
         highestTemperature = 30,
         place = "岐阜",
         temperature = 20,
+        dateTime = LocalDateTime.now(),
     )
 
     override val values: Sequence<WeatherInfoData>

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -69,7 +69,7 @@ fun WeatherApp(
         NavHost(
             navController = navController,
             startDestination = Route.WeatherMain.name,
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         ) {
             composable(Route.WeatherMain.name) {
                 WeatherAppMainContent(
@@ -86,7 +86,7 @@ fun WeatherApp(
             composable(Route.WeatherDetail.name) {
                 WeatherAppDetailContent(
                     weatherInfoData = weatherInfoData,
-                    forecastWeatherInfoDataList = forecastWeatherInfoDataList
+                    forecastWeatherInfoDataList = forecastWeatherInfoDataList,
                 )
             }
         }
@@ -108,7 +108,7 @@ fun PreviewWeatherApp() {
             highestTemperature = 40,
             place = "岐阜",
             temperature = 10,
-            dateTime = LocalDateTime.now()
+            dateTime = LocalDateTime.now(),
         ),
     )
     YumemiTheme {
@@ -127,7 +127,7 @@ fun DarkPreviewWeatherApp() {
             highestTemperature = 40,
             place = "岐阜",
             temperature = 10,
-            dateTime = LocalDateTime.now()
+            dateTime = LocalDateTime.now(),
         ),
     )
     YumemiTheme {
@@ -166,4 +166,3 @@ fun PreviewAllWeatherApp(
     )
     WeatherApp(mainViewModel = mainViewModel)
 }
-

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -4,14 +4,10 @@ import WeatherFetchErrorDialog
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -21,24 +17,23 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import jp.co.yumemi.api.YumemiWeather
 import jp.co.yumemi.droidtraining.FakeWeatherMainViewModel
 import jp.co.yumemi.droidtraining.R
@@ -67,6 +62,8 @@ fun WeatherApp(
         },
     )
 
+    val navController = rememberNavController()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -77,57 +74,32 @@ fun WeatherApp(
                 ),
             )
         },
-    ) {
-        WeatherAppContent(
-            modifier = Modifier.padding(it),
-            weatherInfoData = weatherInfoData,
-            onReloadClick = {
-                mainViewModel.reloadWeather()
-            },
-            enabled = !updating,
-        )
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = Route.WeatherMain.name,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable(Route.WeatherMain.name) {
+                WeatherAppMainContent(
+                    weatherInfoData = weatherInfoData,
+                    onReloadClick = {
+                        mainViewModel.reloadWeather()
+                    },
+                    onNextClick = {
+                        navController.navigate(Route.WeatherDetail.name)
+                    },
+                    enabled = !updating,
+                )
+            }
+            composable(Route.WeatherDetail.name) {
+                WeatherAppDetailContent()
+            }
+        }
     }
 
     if (updating) {
         LoadingOverlay()
-    }
-}
-
-@Composable
-fun WeatherAppContent(
-    modifier: Modifier = Modifier,
-    weatherInfoData: WeatherInfoData,
-    enabled: Boolean = true,
-    onReloadClick: () -> Unit,
-) {
-    BoxWithConstraints(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        val screenWidth = with(LocalDensity.current) { constraints.maxWidth.toDp() }
-        val width = screenWidth / 2
-        Column(modifier = Modifier.width(width)) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .weight(1f)
-                    .padding(8.dp),
-                contentAlignment = Alignment.BottomCenter,
-            ) {
-                Text(text = weatherInfoData.place, fontSize = 20.sp)
-            }
-            WeatherInfo(weatherInfoData)
-
-            ActionButtons(
-                modifier = Modifier
-                    .padding(top = 80.dp)
-                    .weight(1f),
-                onReloadClick = {
-                    onReloadClick()
-                },
-                enabled = enabled,
-            )
-        }
     }
 }
 
@@ -254,15 +226,3 @@ fun PreviewAllWeatherApp(
     WeatherApp(mainViewModel = mainViewModel)
 }
 
-@Composable
-@Preview
-fun PreviewWeatherInfo() {
-    val weather = WeatherInfoData(WeatherType.SUNNY, 10, 20, "岐阜")
-    WeatherInfo(weatherInfoData = weather)
-}
-
-@Composable
-@Preview
-fun PreviewActionButtons() {
-    ActionButtons()
-}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -2,13 +2,7 @@ package jp.co.yumemi.droidtraining.components
 
 import WeatherFetchErrorDialog
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -18,14 +12,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -100,65 +88,6 @@ fun WeatherApp(
 
     if (updating) {
         LoadingOverlay()
-    }
-}
-
-@Composable
-fun WeatherInfo(weatherInfoData: WeatherInfoData, modifier: Modifier = Modifier) {
-    Column(modifier = modifier) {
-        Image(
-            painter = painterResource(id = weatherInfoData.icon),
-            contentDescription = weatherInfoData.weather.id,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RectangleShape),
-        )
-        WeatherTemperatureText(weather = weatherInfoData)
-    }
-}
-
-@Composable
-fun WeatherTemperatureText(weather: WeatherInfoData) {
-    Row {
-        Text(
-            text = "${weather.lowestTemperature}℃",
-            textAlign = TextAlign.Center,
-            modifier = Modifier.weight(1f),
-            color = Color.Blue,
-        )
-        Text(
-            text = "${weather.highestTemperature}℃",
-            textAlign = TextAlign.Center,
-            modifier = Modifier.weight(1f),
-            color = Color.Red,
-        )
-    }
-}
-
-@Composable
-fun ActionButtons(
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    onReloadClick: () -> Unit = {},
-    onNextClick: () -> Unit = {},
-) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceEvenly,
-    ) {
-        Button(onClick = onReloadClick, enabled = enabled) {
-            Text(
-                text = stringResource(id = R.string.reload),
-                style = MaterialTheme.typography.labelMedium,
-            )
-        }
-        Button(onClick = onNextClick, enabled = enabled) {
-            Text(
-                text = stringResource(id = R.string.next),
-                style = MaterialTheme.typography.labelMedium,
-            )
-        }
     }
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -101,6 +101,7 @@ fun PreviewWeatherApp() {
             lowestTemperature = 5,
             highestTemperature = 40,
             place = "岐阜",
+            temperature = 10,
         ),
     )
     YumemiTheme {
@@ -118,6 +119,7 @@ fun DarkPreviewWeatherApp() {
             lowestTemperature = 5,
             highestTemperature = 40,
             place = "岐阜",
+            temperature = 10,
         ),
     )
     YumemiTheme {
@@ -131,6 +133,7 @@ class WeatherAppPreviewParameterProvider : PreviewParameterProvider<WeatherInfoD
         lowestTemperature = 10,
         highestTemperature = 30,
         place = "岐阜",
+        temperature = 20,
     )
 
     override val values: Sequence<WeatherInfoData>

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -31,14 +31,13 @@ import java.time.format.DateTimeFormatter
 fun WeatherAppDetailContent(
     weatherInfoData: WeatherInfoData,
     forecastWeatherInfoDataList: List<WeatherInfoData>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         WeatherInfoDataPlaceText(place = weatherInfoData.place)
         ForecastWeatherInfoDataList(forecastWeatherInfoDataList = forecastWeatherInfoDataList)
     }
 }
-
 
 @Composable
 fun WeatherInfoDataPlaceText(place: String) {
@@ -55,7 +54,8 @@ fun ForecastWeatherInfoData(forecastWeatherInfoData: WeatherInfoData) {
     val timeText = DateTimeFormatter.ofPattern("HH時")
         .format(forecastWeatherInfoData.dateTime)
     val dateTimeText = """$dateText
-        |$timeText""".trimMargin()
+        |$timeText
+    """.trimMargin()
     ElevatedCard(
         elevation = CardDefaults.cardElevation(
             defaultElevation = 4.dp,
@@ -63,14 +63,14 @@ fun ForecastWeatherInfoData(forecastWeatherInfoData: WeatherInfoData) {
         modifier = Modifier
             .padding(vertical = 8.dp, horizontal = 20.dp)
             .fillMaxWidth()
-            .height(70.dp)
+            .height(70.dp),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxHeight()
                 .padding(4.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceAround
+            horizontalArrangement = Arrangement.SpaceAround,
         ) {
             Text(
                 text = dateTimeText,
@@ -128,14 +128,14 @@ fun WeatherAppDetailContentPreview() {
         fakeForecastWeatherInfoDataList.add(
             fakeForecastWeatherInfoData.copy(
                 lowestTemperature = i.toShort(),
-                highestTemperature = (i + 10).toShort()
-            )
+                highestTemperature = (i + 10).toShort(),
+            ),
         )
     }
 
     WeatherAppDetailContent(
         initialWeatherInfoData,
-        forecastWeatherInfoDataList = fakeForecastWeatherInfoDataList
+        forecastWeatherInfoDataList = fakeForecastWeatherInfoDataList,
     )
 }
 
@@ -143,8 +143,7 @@ fun WeatherAppDetailContentPreview() {
 @Composable
 fun ForecastWeatherInfoPreview(
     @PreviewParameter(WeatherAppPreviewParameterProvider::class)
-    weatherInfoData: WeatherInfoData
+    weatherInfoData: WeatherInfoData,
 ) {
     ForecastWeatherInfoData(weatherInfoData)
 }
-

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -28,28 +28,14 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Composable
-fun WeatherAppDetailContent(weatherInfoData: WeatherInfoData, modifier: Modifier = Modifier) {
-    val fakeForecastWeatherInfoData = WeatherInfoData(
-        weather = WeatherType.SUNNY,
-        lowestTemperature = 10,
-        highestTemperature = 20,
-        place = "岐阜",
-        temperature = 15,
-        dateTime = LocalDateTime.now(),
-    )
-    val fakeForecastWeatherInfoDataList = mutableListOf<WeatherInfoData>()
-    for (i in 1..10) {
-        fakeForecastWeatherInfoDataList.add(
-            fakeForecastWeatherInfoData.copy(
-                lowestTemperature = i.toShort(),
-                highestTemperature = (i + 10).toShort()
-            )
-        )
-    }
-
+fun WeatherAppDetailContent(
+    weatherInfoData: WeatherInfoData,
+    forecastWeatherInfoDataList: List<WeatherInfoData>,
+    modifier: Modifier = Modifier
+) {
     Column(modifier = modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         WeatherInfoDataPlaceText(place = weatherInfoData.place)
-        ForecastWeatherInfoDataList(forecastWeatherInfoDataList = fakeForecastWeatherInfoDataList)
+        ForecastWeatherInfoDataList(forecastWeatherInfoDataList = forecastWeatherInfoDataList)
     }
 }
 
@@ -128,7 +114,29 @@ fun WeatherAppDetailContentPreview() {
         temperature = 15,
         dateTime = LocalDateTime.now(),
     )
-    WeatherAppDetailContent(initialWeatherInfoData)
+
+    val fakeForecastWeatherInfoData = WeatherInfoData(
+        weather = WeatherType.SUNNY,
+        lowestTemperature = 10,
+        highestTemperature = 20,
+        place = "岐阜",
+        temperature = 15,
+        dateTime = LocalDateTime.now(),
+    )
+    val fakeForecastWeatherInfoDataList = mutableListOf<WeatherInfoData>()
+    for (i in 1..10) {
+        fakeForecastWeatherInfoDataList.add(
+            fakeForecastWeatherInfoData.copy(
+                lowestTemperature = i.toShort(),
+                highestTemperature = (i + 10).toShort()
+            )
+        )
+    }
+
+    WeatherAppDetailContent(
+        initialWeatherInfoData,
+        forecastWeatherInfoDataList = fakeForecastWeatherInfoDataList
+    )
 }
 
 @Preview

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import jp.co.yumemi.droidtraining.WeatherType
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Composable
@@ -33,6 +34,7 @@ fun WeatherAppDetailContent(weatherInfoData: WeatherInfoData, modifier: Modifier
         highestTemperature = 20,
         place = "岐阜",
         temperature = 15,
+        dateTime = LocalDateTime.now(),
     )
     val fakeForecastWeatherInfoDataList = mutableListOf<WeatherInfoData>()
     for (i in 1..10) {
@@ -123,6 +125,7 @@ fun WeatherAppDetailContentPreview() {
         highestTemperature = 20,
         place = "岐阜",
         temperature = 15,
+        dateTime = LocalDateTime.now(),
     )
     WeatherAppDetailContent(initialWeatherInfoData)
 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -53,17 +54,21 @@ fun WeatherAppDetailContent(weatherInfoData: WeatherInfoData, modifier: Modifier
 fun WeatherInfoDataPlaceText(place: String) {
     Text(
         text = place,
-        fontSize = 20.sp,
+        fontSize = 36.sp,
     )
 }
 
 @Composable
 fun ForecastWeatherInfoData(forecastWeatherInfoData: WeatherInfoData) {
-    val dateText = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")
+    val dateText = DateTimeFormatter.ofPattern("yyyy/MM/dd")
         .format(forecastWeatherInfoData.dateTime)
+    val timeText = DateTimeFormatter.ofPattern("HH時")
+        .format(forecastWeatherInfoData.dateTime)
+    val dateTimeText = """$dateText
+        |$timeText""".trimMargin()
     ElevatedCard(
         elevation = CardDefaults.cardElevation(
-            defaultElevation = 6.dp,
+            defaultElevation = 4.dp,
         ),
         modifier = Modifier
             .padding(vertical = 8.dp, horizontal = 20.dp)
@@ -78,11 +83,12 @@ fun ForecastWeatherInfoData(forecastWeatherInfoData: WeatherInfoData) {
             horizontalArrangement = Arrangement.SpaceAround
         ) {
             Text(
-                text = dateText,
+                text = dateTimeText,
                 modifier = Modifier
-                    .weight(1f)
-                    .align(Alignment.CenterVertically),
+                    .weight(1f),
                 textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
             )
             WeatherInfoIcon(
                 weatherInfoData = forecastWeatherInfoData,
@@ -92,7 +98,7 @@ fun ForecastWeatherInfoData(forecastWeatherInfoData: WeatherInfoData) {
                 text = "${forecastWeatherInfoData.temperature}℃",
                 modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Center,
-                fontSize = 20.sp,
+                fontSize = 24.sp,
             )
         }
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -32,6 +32,7 @@ fun WeatherAppDetailContent(weatherInfoData: WeatherInfoData, modifier: Modifier
         lowestTemperature = 10,
         highestTemperature = 20,
         place = "岐阜",
+        temperature = 15,
     )
     val fakeForecastWeatherInfoDataList = mutableListOf<WeatherInfoData>()
     for (i in 1..10) {
@@ -121,6 +122,7 @@ fun WeatherAppDetailContentPreview() {
         lowestTemperature = 10,
         highestTemperature = 20,
         place = "岐阜",
+        temperature = 15,
     )
     WeatherAppDetailContent(initialWeatherInfoData)
 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -1,0 +1,9 @@
+package jp.co.yumemi.droidtraining.components
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun WeatherAppDetailContent() {
+    Text("Detail Content")
+}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -10,7 +10,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -60,14 +61,19 @@ fun WeatherInfoDataPlaceText(place: String) {
 fun ForecastWeatherInfoData(forecastWeatherInfoData: WeatherInfoData) {
     val dateText = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")
         .format(forecastWeatherInfoData.dateTime)
-    Card(
+    ElevatedCard(
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 6.dp,
+        ),
         modifier = Modifier
             .padding(vertical = 8.dp, horizontal = 20.dp)
             .fillMaxWidth()
-            .height(50.dp)
+            .height(70.dp)
     ) {
         Row(
-            modifier = Modifier.fillMaxHeight(),
+            modifier = Modifier
+                .fillMaxHeight()
+                .padding(4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceAround
         ) {
@@ -86,6 +92,7 @@ fun ForecastWeatherInfoData(forecastWeatherInfoData: WeatherInfoData) {
                 text = "${forecastWeatherInfoData.temperature}℃",
                 modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Center,
+                fontSize = 20.sp,
             )
         }
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import jp.co.yumemi.droidtraining.WeatherType
@@ -128,5 +129,14 @@ fun WeatherAppDetailContentPreview() {
         dateTime = LocalDateTime.now(),
     )
     WeatherAppDetailContent(initialWeatherInfoData)
+}
+
+@Preview
+@Composable
+fun ForecastWeatherInfoPreview(
+    @PreviewParameter(WeatherAppPreviewParameterProvider::class)
+    weatherInfoData: WeatherInfoData
+) {
+    ForecastWeatherInfoData(weatherInfoData)
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -1,9 +1,114 @@
 package jp.co.yumemi.droidtraining.components
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jp.co.yumemi.droidtraining.WeatherType
+import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import java.time.format.DateTimeFormatter
 
 @Composable
-fun WeatherAppDetailContent() {
-    Text("Detail Content")
+fun WeatherAppDetailContent(weatherInfoData: WeatherInfoData, modifier: Modifier = Modifier) {
+    val fakeForecastWeatherInfoData = WeatherInfoData(
+        weather = WeatherType.SUNNY,
+        lowestTemperature = 10,
+        highestTemperature = 20,
+        place = "岐阜",
+    )
+    val fakeForecastWeatherInfoDataList = mutableListOf<WeatherInfoData>()
+    for (i in 1..10) {
+        fakeForecastWeatherInfoDataList.add(
+            fakeForecastWeatherInfoData.copy(
+                lowestTemperature = i.toShort(),
+                highestTemperature = (i + 10).toShort()
+            )
+        )
+    }
+
+    Column(modifier = modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+        WeatherInfoDataPlaceText(place = weatherInfoData.place)
+        ForecastWeatherInfoDataList(forecastWeatherInfoDataList = fakeForecastWeatherInfoDataList)
+    }
 }
+
+
+@Composable
+fun WeatherInfoDataPlaceText(place: String) {
+    Text(
+        text = place,
+        fontSize = 20.sp,
+    )
+}
+
+@Composable
+fun ForecastWeatherInfoData(forecastWeatherInfoData: WeatherInfoData) {
+    val dateText = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")
+        .format(forecastWeatherInfoData.dateTime)
+    Card(
+        modifier = Modifier
+            .padding(vertical = 8.dp, horizontal = 20.dp)
+            .fillMaxWidth()
+            .height(50.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxHeight(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceAround
+        ) {
+            Text(
+                text = dateText,
+                modifier = Modifier
+                    .weight(1f)
+                    .align(Alignment.CenterVertically),
+                textAlign = TextAlign.Center,
+            )
+            WeatherInfoIcon(
+                weatherInfoData = forecastWeatherInfoData,
+                modifier = Modifier.fillMaxHeight(),
+            )
+            Text(
+                text = "${forecastWeatherInfoData.temperature}℃",
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+fun ForecastWeatherInfoDataList(forecastWeatherInfoDataList: List<WeatherInfoData>) {
+    LazyColumn {
+        items(forecastWeatherInfoDataList) { forecastWeatherInfoData ->
+            ForecastWeatherInfoData(forecastWeatherInfoData)
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun WeatherAppDetailContentPreview() {
+    val initialWeatherInfoData = WeatherInfoData(
+        weather = WeatherType.SUNNY,
+        lowestTemperature = 10,
+        highestTemperature = 20,
+        place = "岐阜",
+    )
+    WeatherAppDetailContent(initialWeatherInfoData)
+}
+

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
@@ -1,0 +1,73 @@
+package jp.co.yumemi.droidtraining.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jp.co.yumemi.droidtraining.WeatherType
+import jp.co.yumemi.droidtraining.model.WeatherInfoData
+
+@Composable
+fun WeatherAppMainContent(
+    modifier: Modifier = Modifier,
+    weatherInfoData: WeatherInfoData,
+    enabled: Boolean = true,
+    onReloadClick: () -> Unit,
+    onNextClick: () -> Unit,
+) {
+    BoxWithConstraints(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        val screenWidth = with(LocalDensity.current) { constraints.maxWidth.toDp() }
+        val width = screenWidth / 2
+        Column(modifier = Modifier.width(width)) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f)
+                    .padding(8.dp),
+                contentAlignment = Alignment.BottomCenter,
+            ) {
+                Text(text = weatherInfoData.place, fontSize = 20.sp)
+            }
+            WeatherInfo(weatherInfoData)
+
+            ActionButtons(
+                modifier = Modifier
+                    .padding(top = 80.dp)
+                    .weight(1f),
+                onReloadClick = {
+                    onReloadClick()
+                },
+                onNextClick = {
+                    onNextClick()
+                },
+                enabled = enabled,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+fun PreviewWeatherInfo() {
+    val weather = WeatherInfoData(WeatherType.SUNNY, 10, 20, "岐阜")
+    WeatherInfo(weatherInfoData = weather)
+}
+
+@Composable
+@Preview
+fun PreviewActionButtons() {
+    ActionButtons()
+}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
@@ -97,7 +97,6 @@ fun WeatherInfoIcon(weatherInfoData: WeatherInfoData, modifier: Modifier = Modif
     )
 }
 
-
 @Composable
 fun WeatherTemperatureText(weather: WeatherInfoData) {
     Row {
@@ -154,5 +153,3 @@ fun PreviewWeatherInfo() {
 fun PreviewActionButtons() {
     ActionButtons()
 }
-
-

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
@@ -1,19 +1,33 @@
 package jp.co.yumemi.droidtraining.components
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import jp.co.yumemi.droidtraining.R
 import jp.co.yumemi.droidtraining.WeatherType
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 
@@ -60,6 +74,65 @@ fun WeatherAppMainContent(
 }
 
 @Composable
+fun WeatherInfo(weatherInfoData: WeatherInfoData, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Image(
+            painter = painterResource(id = weatherInfoData.icon),
+            contentDescription = weatherInfoData.weather.id,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RectangleShape),
+        )
+        WeatherTemperatureText(weather = weatherInfoData)
+    }
+}
+
+@Composable
+fun WeatherTemperatureText(weather: WeatherInfoData) {
+    Row {
+        Text(
+            text = "${weather.lowestTemperature}℃",
+            textAlign = TextAlign.Center,
+            modifier = Modifier.weight(1f),
+            color = Color.Blue,
+        )
+        Text(
+            text = "${weather.highestTemperature}℃",
+            textAlign = TextAlign.Center,
+            modifier = Modifier.weight(1f),
+            color = Color.Red,
+        )
+    }
+}
+
+@Composable
+fun ActionButtons(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onReloadClick: () -> Unit = {},
+    onNextClick: () -> Unit = {},
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        Button(onClick = onReloadClick, enabled = enabled) {
+            Text(
+                text = stringResource(id = R.string.reload),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+        Button(onClick = onNextClick, enabled = enabled) {
+            Text(
+                text = stringResource(id = R.string.next),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+    }
+}
+
+@Composable
 @Preview
 fun PreviewWeatherInfo() {
     val weather = WeatherInfoData(WeatherType.SUNNY, 10, 20, "岐阜")
@@ -71,3 +144,5 @@ fun PreviewWeatherInfo() {
 fun PreviewActionButtons() {
     ActionButtons()
 }
+
+

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
@@ -76,10 +76,8 @@ fun WeatherAppMainContent(
 @Composable
 fun WeatherInfo(weatherInfoData: WeatherInfoData, modifier: Modifier = Modifier) {
     Column(modifier = modifier) {
-        Image(
-            painter = painterResource(id = weatherInfoData.icon),
-            contentDescription = weatherInfoData.weather.id,
-            contentScale = ContentScale.Crop,
+        WeatherInfoIcon(
+            weatherInfoData = weatherInfoData,
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RectangleShape),
@@ -87,6 +85,17 @@ fun WeatherInfo(weatherInfoData: WeatherInfoData, modifier: Modifier = Modifier)
         WeatherTemperatureText(weather = weatherInfoData)
     }
 }
+
+@Composable
+fun WeatherInfoIcon(weatherInfoData: WeatherInfoData, modifier: Modifier = Modifier) {
+    Image(
+        painter = painterResource(id = weatherInfoData.icon),
+        contentDescription = weatherInfoData.weather.id,
+        contentScale = ContentScale.Crop,
+        modifier = modifier,
+    )
+}
+
 
 @Composable
 fun WeatherTemperatureText(weather: WeatherInfoData) {

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.sp
 import jp.co.yumemi.droidtraining.R
 import jp.co.yumemi.droidtraining.WeatherType
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import java.time.LocalDateTime
 
 @Composable
 fun WeatherAppMainContent(
@@ -144,7 +145,7 @@ fun ActionButtons(
 @Composable
 @Preview
 fun PreviewWeatherInfo() {
-    val weather = WeatherInfoData(WeatherType.SUNNY, 10, 20, "岐阜", 15)
+    val weather = WeatherInfoData(WeatherType.SUNNY, 10, 20, "岐阜", 15, LocalDateTime.now())
     WeatherInfo(weatherInfoData = weather)
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppMainContent.kt
@@ -144,7 +144,7 @@ fun ActionButtons(
 @Composable
 @Preview
 fun PreviewWeatherInfo() {
-    val weather = WeatherInfoData(WeatherType.SUNNY, 10, 20, "岐阜")
+    val weather = WeatherInfoData(WeatherType.SUNNY, 10, 20, "岐阜", 15)
     WeatherInfo(weatherInfoData = weather)
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -64,14 +64,14 @@ data class WeatherInfoData(
             val lowestTemperature = currentWeatherData.main.tempMin.roundToInt().toShort()
             val place = currentWeatherData.name
             val temp = currentWeatherData.main.temp.roundToInt().toShort()
-            //TODO: 時刻変換
+            val dateTime = LocalDateTime.parse(currentWeatherData.dt.toString())
             return WeatherInfoData(
                 weather = weatherType,
                 highestTemperature = highestTemperature,
                 lowestTemperature = lowestTemperature,
                 place = place,
                 temperature = temp,
-                dateTime = LocalDateTime.now(),
+                dateTime = dateTime,
             )
         }
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -9,6 +9,7 @@ import jp.co.yumemi.droidtraining.WeatherType
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import kotlin.math.roundToInt
 
 /** 仮天気情報
@@ -64,7 +65,7 @@ data class WeatherInfoData(
             val lowestTemperature = currentWeatherData.main.tempMin.roundToInt().toShort()
             val place = currentWeatherData.name
             val temp = currentWeatherData.main.temp.roundToInt().toShort()
-            val dateTime = LocalDateTime.parse(currentWeatherData.dt.toString())
+            val dateTime = LocalDateTime.ofEpochSecond(currentWeatherData.dt, 0, ZoneOffset.UTC)
             return WeatherInfoData(
                 weather = weatherType,
                 highestTemperature = highestTemperature,

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -8,6 +8,8 @@ import jp.co.yumemi.droidtraining.R
 import jp.co.yumemi.droidtraining.WeatherType
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
+import java.time.LocalDate
+import java.time.LocalTime
 import kotlin.math.roundToInt
 
 /** 仮天気情報
@@ -19,6 +21,8 @@ data class WeatherInfoData(
     val lowestTemperature: Short,
     val highestTemperature: Short,
     val place: String,
+    val date: LocalDate = LocalDate.now(),
+    val time: LocalTime = LocalTime.now(),
 ) : Parcelable {
 
     companion object {

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -21,7 +21,7 @@ data class WeatherInfoData(
     val highestTemperature: Short,
     val place: String,
     val temperature: Short,
-    val dateTime: LocalDateTime = LocalDateTime.now(),  //TODO: 今後のためにデフォルトではなくす
+    val dateTime: LocalDateTime,
 ) : Parcelable {
 
     companion object {
@@ -46,6 +46,7 @@ data class WeatherInfoData(
                     lowestTemperature = jsonWeatherInfoData.minTemp.toShort(),
                     place = jsonWeatherInfoData.area,
                     temperature = 255,
+                    dateTime = LocalDateTime.now(),
                 )
             } catch (e: NoSuchElementException) {
                 // 該当するWeatherTypeがない場合
@@ -63,12 +64,14 @@ data class WeatherInfoData(
             val lowestTemperature = currentWeatherData.main.tempMin.roundToInt().toShort()
             val place = currentWeatherData.name
             val temp = currentWeatherData.main.temp.roundToInt().toShort()
+            //TODO: 時刻変換
             return WeatherInfoData(
                 weather = weatherType,
                 highestTemperature = highestTemperature,
                 lowestTemperature = lowestTemperature,
                 place = place,
                 temperature = temp,
+                dateTime = LocalDateTime.now(),
             )
         }
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -20,7 +20,7 @@ data class WeatherInfoData(
     val lowestTemperature: Short,
     val highestTemperature: Short,
     val place: String,
-    val temperature: Short = -1,    //TODO: デフォルトではなくす
+    val temperature: Short,
     val dateTime: LocalDateTime = LocalDateTime.now(),  //TODO: 今後のためにデフォルトではなくす
 ) : Parcelable {
 
@@ -45,6 +45,7 @@ data class WeatherInfoData(
                     highestTemperature = jsonWeatherInfoData.maxTemp.toShort(),
                     lowestTemperature = jsonWeatherInfoData.minTemp.toShort(),
                     place = jsonWeatherInfoData.area,
+                    temperature = 255,
                 )
             } catch (e: NoSuchElementException) {
                 // 該当するWeatherTypeがない場合
@@ -61,11 +62,13 @@ data class WeatherInfoData(
             val highestTemperature = currentWeatherData.main.tempMax.roundToInt().toShort()
             val lowestTemperature = currentWeatherData.main.tempMin.roundToInt().toShort()
             val place = currentWeatherData.name
+            val temp = currentWeatherData.main.temp.roundToInt().toShort()
             return WeatherInfoData(
                 weather = weatherType,
                 highestTemperature = highestTemperature,
                 lowestTemperature = lowestTemperature,
                 place = place,
+                temperature = temp,
             )
         }
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -8,8 +8,7 @@ import jp.co.yumemi.droidtraining.R
 import jp.co.yumemi.droidtraining.WeatherType
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
-import java.time.LocalDate
-import java.time.LocalTime
+import java.time.LocalDateTime
 import kotlin.math.roundToInt
 
 /** 仮天気情報
@@ -21,8 +20,7 @@ data class WeatherInfoData(
     val lowestTemperature: Short,
     val highestTemperature: Short,
     val place: String,
-    val date: LocalDate = LocalDate.now(),  //TODO: 今後のためにデフォルトではなくす
-    val time: LocalTime = LocalTime.now(),
+    val dateTime: LocalDateTime = LocalDateTime.now(),  //TODO: 今後のためにデフォルトではなくす
 ) : Parcelable {
 
     companion object {

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -21,7 +21,7 @@ data class WeatherInfoData(
     val lowestTemperature: Short,
     val highestTemperature: Short,
     val place: String,
-    val date: LocalDate = LocalDate.now(),
+    val date: LocalDate = LocalDate.now(),  //TODO: 今後のためにデフォルトではなくす
     val time: LocalTime = LocalTime.now(),
 ) : Parcelable {
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -20,6 +20,7 @@ data class WeatherInfoData(
     val lowestTemperature: Short,
     val highestTemperature: Short,
     val place: String,
+    val temperature: Short = -1,    //TODO: デフォルトではなくす
     val dateTime: LocalDateTime = LocalDateTime.now(),  //TODO: 今後のためにデフォルトではなくす
 ) : Parcelable {
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 interface WeatherInfoDataRepository {
@@ -25,6 +26,7 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
         highestTemperature = 40,
         place = "岐阜",
         temperature = 10,
+        dateTime = LocalDateTime.now()
     ),
     private val currentWeatherDataAPI: CurrentWeatherDataAPI,
     private val fetchDispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
@@ -24,6 +24,7 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
         lowestTemperature = 5,
         highestTemperature = 40,
         place = "岐阜",
+        temperature = 10,
     ),
     private val currentWeatherDataAPI: CurrentWeatherDataAPI,
     private val fetchDispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
@@ -15,6 +15,7 @@ import javax.inject.Inject
 
 interface WeatherInfoDataRepository {
     val weatherInfoData: StateFlow<WeatherInfoData>
+    val foreCastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
     suspend fun updateWeatherInfoData()
     fun setWeatherInfoData(weatherInfoData: WeatherInfoData)
 }
@@ -34,6 +35,10 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
 
     private val _weatherInfoData = MutableStateFlow(initialWeatherInfoData)
     override val weatherInfoData = _weatherInfoData.asStateFlow()
+
+    private val _foreCastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
+    override val foreCastWeatherInfoDataList = _foreCastWeatherInfoDataList.asStateFlow()
+
 
     /** 天気情報取得
      * @return 新しい天気情報

--- a/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 
 interface WeatherInfoDataRepository {
     val weatherInfoData: StateFlow<WeatherInfoData>
-    val foreCastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
+    val forecastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
     suspend fun updateWeatherInfoData()
     fun setWeatherInfoData(weatherInfoData: WeatherInfoData)
 }
@@ -36,8 +36,8 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
     private val _weatherInfoData = MutableStateFlow(initialWeatherInfoData)
     override val weatherInfoData = _weatherInfoData.asStateFlow()
 
-    private val _foreCastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
-    override val foreCastWeatherInfoDataList = _foreCastWeatherInfoDataList.asStateFlow()
+    private val _forecastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
+    override val forecastWeatherInfoDataList = _forecastWeatherInfoDataList.asStateFlow()
 
 
     /** 天気情報取得

--- a/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
@@ -57,12 +57,35 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
         return _weatherInfoData.value
     }
 
+    private suspend fun fetchForecastWeatherInfoDataList(): List<WeatherInfoData> {
+        //TODO: APIからに変更する
+        val fakeForecastWeatherInfoData = WeatherInfoData(
+            weather = WeatherType.SUNNY,
+            lowestTemperature = 10,
+            highestTemperature = 20,
+            place = "岐阜",
+            temperature = 15,
+            dateTime = LocalDateTime.now(),
+        )
+        val fakeForecastWeatherInfoDataList = mutableListOf<WeatherInfoData>()
+        for (i in 1..10) {
+            fakeForecastWeatherInfoDataList.add(
+                fakeForecastWeatherInfoData.copy(
+                    lowestTemperature = i.toShort(),
+                    highestTemperature = (i + 10).toShort()
+                )
+            )
+        }
+        return fakeForecastWeatherInfoDataList
+    }
+
     /**
-     * 天気情報を更新
+     * 天気情報＆予報情報を更新
      * @throws UnknownException 天気取得できなかった場合
      */
     override suspend fun updateWeatherInfoData() {
         _weatherInfoData.value = fetchWeatherInfoData()
+        _forecastWeatherInfoDataList.value = fetchForecastWeatherInfoDataList()
     }
 
     override fun setWeatherInfoData(weatherInfoData: WeatherInfoData) {

--- a/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
@@ -27,7 +27,7 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
         highestTemperature = 40,
         place = "岐阜",
         temperature = 10,
-        dateTime = LocalDateTime.now()
+        dateTime = LocalDateTime.now(),
     ),
     private val currentWeatherDataAPI: CurrentWeatherDataAPI,
     private val fetchDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -38,7 +38,6 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
 
     private val _forecastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
     override val forecastWeatherInfoDataList = _forecastWeatherInfoDataList.asStateFlow()
-
 
     /** 天気情報取得
      * @return 新しい天気情報
@@ -58,7 +57,7 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetchForecastWeatherInfoDataList(): List<WeatherInfoData> {
-        //TODO: APIからに変更する
+        // TODO: APIからに変更する
         val fakeForecastWeatherInfoData = WeatherInfoData(
             weather = WeatherType.SUNNY,
             lowestTemperature = 10,
@@ -72,8 +71,8 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
             fakeForecastWeatherInfoDataList.add(
                 fakeForecastWeatherInfoData.copy(
                     lowestTemperature = i.toShort(),
-                    highestTemperature = (i + 10).toShort()
-                )
+                    highestTemperature = (i + 10).toShort(),
+                ),
             )
         }
         return fakeForecastWeatherInfoDataList

--- a/app/src/main/java/jp/co/yumemi/droidtraining/usecases/GetForecastWeatherInfoDataUseCase.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/usecases/GetForecastWeatherInfoDataUseCase.kt
@@ -4,7 +4,7 @@ import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import javax.inject.Inject
 
 class GetForecastWeatherInfoDataUseCase @Inject constructor(
-    private val weatherInfoDataRepository: WeatherInfoDataRepository
+    private val weatherInfoDataRepository: WeatherInfoDataRepository,
 ) {
     operator fun invoke() = weatherInfoDataRepository.forecastWeatherInfoDataList
 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/usecases/GetForecastWeatherInfoDataUseCase.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/usecases/GetForecastWeatherInfoDataUseCase.kt
@@ -1,0 +1,10 @@
+package jp.co.yumemi.droidtraining.usecases
+
+import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
+import javax.inject.Inject
+
+class GetForecastWeatherInfoDataUseCase @Inject constructor(
+    private val weatherInfoDataRepository: WeatherInfoDataRepository
+) {
+    operator fun invoke() = weatherInfoDataRepository.forecastWeatherInfoDataList
+}

--- a/app/src/test/java/jp/co/yumemi/droidtraining/WeatherInfoDataRepositoryTest.kt
+++ b/app/src/test/java/jp/co/yumemi/droidtraining/WeatherInfoDataRepositoryTest.kt
@@ -7,6 +7,7 @@ import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepositoryImpl
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import java.time.LocalDateTime
 
 class WeatherInfoDataRepositoryTest {
     class FakeCurrentWeatherDataAPI(private val _fetchCurrentWeatherData: (cityId: CurrentWeatherDataAPI.CityId) -> CurrentWeatherData) :
@@ -69,6 +70,8 @@ class WeatherInfoDataRepositoryTest {
             lowestTemperature = 5,
             highestTemperature = 40,
             place = "岐阜",
+            temperature = 10,
+            dateTime = LocalDateTime.now(),
         )
         val repository = WeatherInfoDataRepositoryImpl(
             initialWeatherInfoData = initialWeatherInfoData,
@@ -84,6 +87,8 @@ class WeatherInfoDataRepositoryTest {
             lowestTemperature = 5,
             highestTemperature = 40,
             place = "岐阜",
+            temperature = 10,
+            dateTime = LocalDateTime.now(),
         )
 
         // フェッチされる天気情報
@@ -92,6 +97,8 @@ class WeatherInfoDataRepositoryTest {
             lowestTemperature = 20,
             highestTemperature = 50,
             place = "東京",
+            temperature = 30,
+            dateTime = LocalDateTime.of(2021, 1, 1, 12, 0),
         )
         val newWeather = currentWeatherData.weather[0].copy(id = 800) // SUNNY id
         val newMain = currentWeatherData.main.copy(
@@ -120,6 +127,8 @@ class WeatherInfoDataRepositoryTest {
             lowestTemperature = 5,
             highestTemperature = 40,
             place = "岐阜",
+            temperature = 10,
+            dateTime = LocalDateTime.now(),
         )
         val repository = WeatherInfoDataRepositoryImpl(
             initialWeatherInfoData = initialWeatherInfoData,

--- a/app/src/test/java/jp/co/yumemi/droidtraining/WeatherInfoDataRepositoryTest.kt
+++ b/app/src/test/java/jp/co/yumemi/droidtraining/WeatherInfoDataRepositoryTest.kt
@@ -8,6 +8,7 @@ import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepositoryImpl
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class WeatherInfoDataRepositoryTest {
     class FakeCurrentWeatherDataAPI(private val _fetchCurrentWeatherData: (cityId: CurrentWeatherDataAPI.CityId) -> CurrentWeatherData) :
@@ -104,11 +105,13 @@ class WeatherInfoDataRepositoryTest {
         val newMain = currentWeatherData.main.copy(
             tempMin = newWeatherInfoData.lowestTemperature.toDouble(),
             tempMax = newWeatherInfoData.highestTemperature.toDouble(),
+            temp = newWeatherInfoData.temperature.toDouble(),
         )
         val newCurrentWeatherData = currentWeatherData.copy(
             weather = listOf(newWeather),
             main = newMain,
             name = newWeatherInfoData.place,
+            dt = newWeatherInfoData.dateTime.toEpochSecond(ZoneOffset.UTC),
         )
 
         // テスト


### PR DESCRIPTION
## 修正内容

Resolve #33 

- ナビゲーションにより、メイン（天気情報）と詳細（天気予報）の画面遷移追加
  - Nextボタンにより遷移
- 天気(WeatherInfoData)に日付、気温情報を追加
  - CurrentWeatherInfoDataからの変換も対応ずみ
- 詳細画面の作成（予報情報リスト）
- リポジトリに予報取得関数追加（ダミー）
  - 上記に伴い、予報情報のViewModelとUseCaseを追加
  - UseCaseから詳細画面に表示


## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [ ] ぱっとみて違和感がないかチェックしてApproveする
- [x] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点

追加・変更点が多くテストも全て通した等確認しましたが、もしかしたら小さな変更ミスがあるかもしれないので確認できたらお願いします

## スクリーンショット

天気詳細画面
<img src="https://github.com/Ryokusa/yumemi-droid-training/assets/57885690/103269c3-3b81-4ad1-a11b-63b6c2bffe1c" width="200px"/> 



## 備考
