### PR TITLE
フェッチキャンセル追加 Issue #76

### DIFF
--- a/app/src/main/java/jp/co/yumemi/droidtraining/WeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/WeatherMainViewModel.kt
@@ -32,12 +32,18 @@ open class WeatherMainViewModel @Inject constructor(
     private var reloadWeatherJob: Job? = null
     private var fetchForecastWeatherJob: Job? = null
 
-    fun reloadWeather(onFailed: () -> Unit) {
+    fun reloadWeather(onFailed: () -> Unit, onCancel: () -> Unit = {}) {
         reloadWeatherJob = viewModelScope.launch {
             _updating.value = true
-            updateWeatherInfoDataUseCase(onFailed = {
-                onFailed()
-            })
+            updateWeatherInfoDataUseCase(
+                onFailed = {
+                    onFailed()
+                },
+                onCancel = {
+                    onCancel()
+                },
+            )
+
             _updating.value = false
         }
     }
@@ -46,12 +52,17 @@ open class WeatherMainViewModel @Inject constructor(
         reloadWeatherJob?.cancel()
     }
 
-    fun fetchForecastWeather(onFailed: () -> Unit) {
+    fun fetchForecastWeather(onFailed: () -> Unit, onCancel: () -> Unit = {}) {
         fetchForecastWeatherJob = viewModelScope.launch {
             _forecastFetching.value = true
-            updateForecastWeatherInfoDataListUseCase(onFailed = {
-                onFailed()
-            })
+            updateForecastWeatherInfoDataListUseCase(
+                onFailed = {
+                    onFailed()
+                },
+                onCancel = {
+                    onCancel()
+                },
+            )
             _forecastFetching.value = false
         }
     }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/WeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/WeatherMainViewModel.kt
@@ -7,6 +7,7 @@ import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -28,8 +29,11 @@ open class WeatherMainViewModel @Inject constructor(
     private val _forecastFetching = MutableStateFlow(false)
     val forecastFetching = _forecastFetching.asStateFlow()
 
+    private var reloadWeatherJob: Job? = null
+    private var fetchForecastWeatherJob: Job? = null
+
     fun reloadWeather(onFailed: () -> Unit) {
-        viewModelScope.launch {
+        reloadWeatherJob = viewModelScope.launch {
             _updating.value = true
             updateWeatherInfoDataUseCase(onFailed = {
                 onFailed()
@@ -38,13 +42,21 @@ open class WeatherMainViewModel @Inject constructor(
         }
     }
 
+    fun cancelReloadWeather() {
+        reloadWeatherJob?.cancel()
+    }
+
     fun fetchForecastWeather(onFailed: () -> Unit) {
-        viewModelScope.launch {
+        fetchForecastWeatherJob = viewModelScope.launch {
             _forecastFetching.value = true
             updateForecastWeatherInfoDataListUseCase(onFailed = {
                 onFailed()
             })
             _forecastFetching.value = false
         }
+    }
+
+    fun cancelFetchForecastWeather() {
+        fetchForecastWeatherJob?.cancel()
     }
 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -91,10 +91,13 @@ fun WeatherApp(
                     WeatherAppDetailContent(
                         weatherInfoData = weatherInfoData,
                         forecastWeatherInfoDataList = forecastWeatherInfoDataList,
-                        updateForecastWeatherInfoDataList = {
+                        fetchForecastWeatherInfoDataList = {
                             mainViewModel.fetchForecastWeather {
                                 showErrorDialog()
                             }
+                        },
+                        canceledUpdateForecastInfoDataList = {
+                            mainViewModel.cancelFetchForecastWeather()
                         },
                     )
                 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -81,9 +81,6 @@ fun WeatherApp(
                             navController.navigate(Route.WeatherDetail.name) {
                                 launchSingleTop = true
                             }
-                            mainViewModel.fetchForecastWeather {
-                                showErrorDialog()
-                            }
                         }
                     },
                     enabled = !updating,
@@ -94,6 +91,11 @@ fun WeatherApp(
                     WeatherAppDetailContent(
                         weatherInfoData = weatherInfoData,
                         forecastWeatherInfoDataList = forecastWeatherInfoDataList,
+                        updateForecastWeatherInfoDataList = {
+                            mainViewModel.fetchForecastWeather {
+                                showErrorDialog()
+                            }
+                        },
                     )
                 }
             }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -72,9 +72,9 @@ fun WeatherApp(
                 WeatherAppMainContent(
                     weatherInfoData = weatherInfoData,
                     onReloadClick = {
-                        mainViewModel.reloadWeather {
+                        mainViewModel.reloadWeather(onFailed = {
                             showErrorDialog()
-                        }
+                        })
                     },
                     onNextClick = {
                         weatherInfoData?.let {
@@ -92,9 +92,11 @@ fun WeatherApp(
                         weatherInfoData = weatherInfoData,
                         forecastWeatherInfoDataList = forecastWeatherInfoDataList,
                         fetchForecastWeatherInfoDataList = {
-                            mainViewModel.fetchForecastWeather {
-                                showErrorDialog()
-                            }
+                            mainViewModel.fetchForecastWeather(
+                                onFailed = {
+                                    showErrorDialog()
+                                },
+                            )
                         },
                         canceledUpdateForecastInfoDataList = {
                             mainViewModel.cancelFetchForecastWeather()
@@ -108,9 +110,9 @@ fun WeatherApp(
                     onDismissRequest = { navController.popBackStack() },
                     onReload = {
                         navController.popBackStack()
-                        mainViewModel.reloadWeather {
+                        mainViewModel.reloadWeather(onFailed = {
                             showErrorDialog()
-                        }
+                        })
                     },
                 )
             }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -31,8 +32,13 @@ import java.time.format.DateTimeFormatter
 fun WeatherAppDetailContent(
     weatherInfoData: WeatherInfoData,
     forecastWeatherInfoDataList: List<WeatherInfoData>,
+    updateForecastWeatherInfoDataList: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    LaunchedEffect(weatherInfoData) {
+        updateForecastWeatherInfoDataList()
+    }
+
     Column(modifier = modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         WeatherInfoDataPlaceText(place = weatherInfoData.place)
         ForecastWeatherInfoDataList(forecastWeatherInfoDataList = forecastWeatherInfoDataList)
@@ -141,6 +147,7 @@ fun WeatherAppDetailContentPreview() {
     WeatherAppDetailContent(
         initialWeatherInfoData,
         forecastWeatherInfoDataList = fakeForecastWeatherInfoDataList,
+        updateForecastWeatherInfoDataList = {},
     )
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -14,9 +14,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,16 +33,20 @@ import java.time.format.DateTimeFormatter
 fun WeatherAppDetailContent(
     weatherInfoData: WeatherInfoData,
     forecastWeatherInfoDataList: List<WeatherInfoData>,
-    updateForecastWeatherInfoDataList: () -> Unit,
+    fetchForecastWeatherInfoDataList: () -> Unit,
+    canceledUpdateForecastInfoDataList: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LaunchedEffect(weatherInfoData) {
-        updateForecastWeatherInfoDataList()
-    }
-
     Column(modifier = modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         WeatherInfoDataPlaceText(place = weatherInfoData.place)
         ForecastWeatherInfoDataList(forecastWeatherInfoDataList = forecastWeatherInfoDataList)
+    }
+
+    DisposableEffect(LocalLifecycleOwner.current) {
+        fetchForecastWeatherInfoDataList()
+        onDispose {
+            canceledUpdateForecastInfoDataList()
+        }
     }
 }
 
@@ -147,7 +152,8 @@ fun WeatherAppDetailContentPreview() {
     WeatherAppDetailContent(
         initialWeatherInfoData,
         forecastWeatherInfoDataList = fakeForecastWeatherInfoDataList,
-        updateForecastWeatherInfoDataList = {},
+        fetchForecastWeatherInfoDataList = {},
+        canceledUpdateForecastInfoDataList = {},
     )
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/repository/WeatherInfoDataRepository.kt
@@ -3,6 +3,7 @@ package jp.co.yumemi.droidtraining.repository
 import com.example.weatherapi.api.OpenWeatherDataAPI
 import jp.co.yumemi.api.UnknownException
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,6 +43,7 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
     /** 天気情報取得
      * @return 新しい天気情報
      * @throws UnknownException 天気取得できなかった場合
+     * @throws CancellationException キャンセルされた場合
      */
     private suspend fun fetchWeatherInfoData(): WeatherInfoData {
         try {
@@ -51,6 +53,8 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
             val newWeatherData = WeatherInfoData(currentWeatherData)
             _weatherInfoData.value = newWeatherData
             return newWeatherData
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             throw UnknownException()
         }
@@ -67,6 +71,8 @@ class WeatherInfoDataRepositoryImpl @Inject constructor(
                 )
             }
             _forecastWeatherInfoDataList.value = forecastDataList
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             throw UnknownException()
         }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/usecases/UpdateForecastWeatherInfoDataListUseCase.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/usecases/UpdateForecastWeatherInfoDataListUseCase.kt
@@ -2,14 +2,17 @@ package jp.co.yumemi.droidtraining.usecases
 
 import jp.co.yumemi.api.UnknownException
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 class UpdateForecastWeatherInfoDataListUseCase @Inject constructor(
     private val weatherInfoDataRepository: WeatherInfoDataRepository,
 ) {
-    suspend operator fun invoke(onFailed: () -> Unit) {
+    suspend operator fun invoke(onFailed: () -> Unit, onCancel: () -> Unit) {
         try {
             weatherInfoDataRepository.updateForecastWeatherInfoDataList()
+        } catch (e: CancellationException) {
+            onCancel()
         } catch (e: UnknownException) {
             onFailed()
         }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/usecases/UpdateWeatherInfoDataUseCase.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/usecases/UpdateWeatherInfoDataUseCase.kt
@@ -2,12 +2,15 @@ package jp.co.yumemi.droidtraining.usecases
 
 import jp.co.yumemi.api.UnknownException
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 class UpdateWeatherInfoDataUseCase @Inject constructor(private val weatherInfoDataRepository: WeatherInfoDataRepository) {
-    suspend operator fun invoke(onFailed: () -> Unit) {
+    suspend operator fun invoke(onFailed: () -> Unit, onCancel: () -> Unit) {
         try {
             weatherInfoDataRepository.updateWeatherInfoData()
+        } catch (e: CancellationException) {
+            onCancel()
         } catch (e: UnknownException) {
             onFailed()
         }


### PR DESCRIPTION
## 修正内容
<!-- 
課題Issueの番号をここに記載してください。
PR画面では自動的にIssueへのURLリンクとなります。
同時にPRとIssueがリンクされ、PRがデフォルトブランチ(main)にマージされると自動でIssueもcloseされます。
参考：https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Resolve #76 

- 予報画面遷移後、予報ローディング中にメイン画面に戻ると自動でキャンセルするよう修正
- 通常天気フェッチもキャンセル機能追加（未使用）


## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [ ] ぱっとみて違和感がないかチェックしてApproveする
- [x] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点

キャンセルの扱い方が合っているか確認お願いします
また、予報画面（詳細画面）へのViewModel機能受け渡しが複雑になっていますが、Issue #80 にて別ViewModelを用意し簡潔にする予定です


## スクリーンショット
変化なし

## 備考
<!--
* マージ先のブランチの設定が正しいか確認してください。
* 動画を添付するときは、GitHubの制限のため、アニメーションGifに変換してください。
-->
