### PR TITLE
詳細画面を別ViewModelに　Issue #80

### DIFF
--- a/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
+++ b/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
@@ -16,6 +16,7 @@ import jp.co.yumemi.droidtraining.components.WeatherApp
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import jp.co.yumemi.droidtraining.theme.YumemiTheme
+import jp.co.yumemi.droidtraining.viewmodels.FakeForecastWeatherViewModel
 import jp.co.yumemi.droidtraining.viewmodels.FakeWeatherMainViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -90,16 +91,20 @@ class WeatherAppUiTest {
         updateFailCount: Int = 0,
         fetchForecastFail: Boolean = false,
     ) {
+        val fakeWeatherInfoDataRepository = FakeWeatherInfoDataRepository(
+            initialWeatherInfoData = initialWeatherInfoData,
+            updatedWeatherInfoData = updatedWeatherInfoData,
+            updateFailCount = updateFailCount,
+            fetchForecastFail = fetchForecastFail,
+        )
         YumemiTheme {
             WeatherApp(
                 mainViewModel = FakeWeatherMainViewModel(
                     initialWeatherInfoData = initialWeatherInfoData,
-                    fakeWeatherInfoDataRepository = FakeWeatherInfoDataRepository(
-                        initialWeatherInfoData = initialWeatherInfoData,
-                        updatedWeatherInfoData = updatedWeatherInfoData,
-                        updateFailCount = updateFailCount,
-                        fetchForecastFail = fetchForecastFail,
-                    ),
+                    fakeWeatherInfoDataRepository = fakeWeatherInfoDataRepository,
+                ),
+                forecastWeatherViewModel = FakeForecastWeatherViewModel(
+                    fakeWeatherInfoDataRepository = fakeWeatherInfoDataRepository,
                 ),
             )
         }

--- a/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
+++ b/app/src/androidTest/java/jp/co/yumemi/droidtraining/WeatherAppUiTest.kt
@@ -16,6 +16,7 @@ import jp.co.yumemi.droidtraining.components.WeatherApp
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import jp.co.yumemi.droidtraining.theme.YumemiTheme
+import jp.co.yumemi.droidtraining.viewmodels.FakeWeatherMainViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/jp/co/yumemi/droidtraining/ForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/ForecastWeatherViewModel.kt
@@ -1,0 +1,44 @@
+package jp.co.yumemi.droidtraining
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
+import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+open class ForecastWeatherViewModel @Inject constructor(
+    getForecastWeatherInfoDataUseCase: GetForecastWeatherInfoDataUseCase,
+    private val updateForecastWeatherInfoDataListUseCase: UpdateForecastWeatherInfoDataListUseCase,
+) : ViewModel() {
+
+    val forecastWeatherInfoDataList = getForecastWeatherInfoDataUseCase()
+    private val _forecastFetching = MutableStateFlow(false)
+    val forecastFetching = _forecastFetching.asStateFlow()
+
+    private var fetchForecastWeatherJob: Job? = null
+
+    open fun fetchForecastWeather(onFailed: () -> Unit, onCancel: () -> Unit = {}) {
+        fetchForecastWeatherJob = viewModelScope.launch {
+            _forecastFetching.value = true
+            updateForecastWeatherInfoDataListUseCase(
+                onFailed = {
+                    onFailed()
+                },
+                onCancel = {
+                    onCancel()
+                },
+            )
+            _forecastFetching.value = false
+        }
+    }
+
+    open fun cancelFetchForecastWeather() {
+        fetchForecastWeatherJob?.cancel()
+    }
+}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/HiltModules.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/HiltModules.kt
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 import jp.co.yumemi.api.YumemiWeather
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepositoryImpl
-import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
 import javax.inject.Singleton
@@ -54,7 +54,7 @@ object HiltModules {
 
     @Provides
     @Singleton
-    fun provideGetForecastWeatherInfoDataUseCase(repository: WeatherInfoDataRepository): GetForecastWeatherInfoDataUseCase {
-        return GetForecastWeatherInfoDataUseCase(repository)
+    fun provideGetForecastWeatherInfoDataUseCase(repository: WeatherInfoDataRepository): GetForecastWeatherInfoDataListUseCase {
+        return GetForecastWeatherInfoDataListUseCase(repository)
     }
 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/Route.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/Route.kt
@@ -2,6 +2,11 @@ package jp.co.yumemi.droidtraining.components
 
 enum class Route {
     WeatherMain,
-    WeatherDetail,
     WeatherFetchErrorDialog,
+    ;
+
+    enum class WeatherDetail {
+        Main,
+        ForecastWeatherFetchErrorDialog,
+    }
 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -74,7 +74,7 @@ fun WeatherApp(
                     },
                     onNextClick = {
                         weatherInfoData?.let {
-                            navController.navigate(Route.WeatherDetail.name) {
+                            navController.navigate(Route.WeatherDetail.Main.name) {
                                 launchSingleTop = true
                             }
                         }
@@ -82,7 +82,7 @@ fun WeatherApp(
                     enabled = !updating,
                 )
             }
-            composable(Route.WeatherDetail.name) {
+            composable(Route.WeatherDetail.Main.name) {
                 weatherInfoData?.let { weatherInfoData ->
                     WeatherAppDetailContent(
                         weatherInfoData = weatherInfoData,

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -29,6 +29,7 @@ import jp.co.yumemi.droidtraining.WeatherType
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.theme.YumemiTheme
 import jp.co.yumemi.droidtraining.viewmodels.FakeWeatherMainViewModel
+import jp.co.yumemi.droidtraining.viewmodels.ForecastWeatherViewModel
 import jp.co.yumemi.droidtraining.viewmodels.WeatherMainViewModel
 import java.time.LocalDateTime
 
@@ -36,6 +37,7 @@ import java.time.LocalDateTime
 @Composable
 fun WeatherApp(
     mainViewModel: WeatherMainViewModel = hiltViewModel(),
+    forecastWeatherViewModel: ForecastWeatherViewModel = hiltViewModel(),
 ) {
     val weatherInfoData by mainViewModel.weatherInfoData.collectAsStateWithLifecycle()
 
@@ -86,6 +88,7 @@ fun WeatherApp(
                 weatherInfoData?.let { weatherInfoData ->
                     WeatherAppDetailContent(
                         weatherInfoData = weatherInfoData,
+                        viewModel = forecastWeatherViewModel,
                     )
                 }
             }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -24,12 +24,12 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.dialog
 import androidx.navigation.compose.rememberNavController
 import jp.co.yumemi.api.YumemiWeather
-import jp.co.yumemi.droidtraining.FakeWeatherMainViewModel
 import jp.co.yumemi.droidtraining.R
-import jp.co.yumemi.droidtraining.WeatherMainViewModel
 import jp.co.yumemi.droidtraining.WeatherType
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.theme.YumemiTheme
+import jp.co.yumemi.droidtraining.viewmodels.FakeWeatherMainViewModel
+import jp.co.yumemi.droidtraining.viewmodels.WeatherMainViewModel
 import java.time.LocalDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherApp.kt
@@ -41,10 +41,6 @@ fun WeatherApp(
 
     val updating by mainViewModel.updating.collectAsStateWithLifecycle()
 
-    val forecastWeatherInfoDataList by mainViewModel.forecastWeatherInfoDataList.collectAsStateWithLifecycle()
-
-    val forecastFetching by mainViewModel.forecastFetching.collectAsStateWithLifecycle()
-
     val navController = rememberNavController()
 
     Scaffold(
@@ -90,17 +86,6 @@ fun WeatherApp(
                 weatherInfoData?.let { weatherInfoData ->
                     WeatherAppDetailContent(
                         weatherInfoData = weatherInfoData,
-                        forecastWeatherInfoDataList = forecastWeatherInfoDataList,
-                        fetchForecastWeatherInfoDataList = {
-                            mainViewModel.fetchForecastWeather(
-                                onFailed = {
-                                    showErrorDialog()
-                                },
-                            )
-                        },
-                        canceledUpdateForecastInfoDataList = {
-                            mainViewModel.cancelFetchForecastWeather()
-                        },
                     )
                 }
             }
@@ -119,7 +104,7 @@ fun WeatherApp(
         }
     }
 
-    if (updating || forecastFetching) {
+    if (updating) {
         LoadingOverlay()
     }
 }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -161,7 +161,6 @@ fun WeatherAppDetailContentPreview() {
         )
     }
 
-    // TODO: プレビュー（FakeViewModelを使う）
     WeatherAppDetailContent(
         initialWeatherInfoData,
         viewModel = FakeForecastWeatherViewModel(

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -24,29 +25,39 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import jp.co.yumemi.droidtraining.WeatherType
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import jp.co.yumemi.droidtraining.viewmodels.ForecastWeatherViewModel
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Composable
 fun WeatherAppDetailContent(
     weatherInfoData: WeatherInfoData,
-    forecastWeatherInfoDataList: List<WeatherInfoData>,
-    fetchForecastWeatherInfoDataList: () -> Unit,
-    canceledUpdateForecastInfoDataList: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: ForecastWeatherViewModel = hiltViewModel(),
 ) {
+    val forecastWeatherInfoDataList by viewModel.forecastWeatherInfoDataList.collectAsStateWithLifecycle()
+    val fetching by viewModel.forecastFetching.collectAsStateWithLifecycle()
+
     Column(modifier = modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         WeatherInfoDataPlaceText(place = weatherInfoData.place)
         ForecastWeatherInfoDataList(forecastWeatherInfoDataList = forecastWeatherInfoDataList)
     }
 
     DisposableEffect(LocalLifecycleOwner.current) {
-        fetchForecastWeatherInfoDataList()
+        viewModel.fetchForecastWeather {}
         onDispose {
-            canceledUpdateForecastInfoDataList()
+            viewModel.cancelFetchForecastWeather()
         }
+    }
+
+    // TODO: エラーダイアログ
+
+    if (fetching) {
+        LoadingOverlay()
     }
 }
 
@@ -149,11 +160,9 @@ fun WeatherAppDetailContentPreview() {
         )
     }
 
+    // TODO: プレビュー（FakeViewModelを使う）
     WeatherAppDetailContent(
         initialWeatherInfoData,
-        forecastWeatherInfoDataList = fakeForecastWeatherInfoDataList,
-        fetchForecastWeatherInfoDataList = {},
-        canceledUpdateForecastInfoDataList = {},
     )
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -29,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import jp.co.yumemi.droidtraining.WeatherType
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import jp.co.yumemi.droidtraining.viewmodels.FakeForecastWeatherViewModel
 import jp.co.yumemi.droidtraining.viewmodels.ForecastWeatherViewModel
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -163,6 +164,9 @@ fun WeatherAppDetailContentPreview() {
     // TODO: プレビュー（FakeViewModelを使う）
     WeatherAppDetailContent(
         initialWeatherInfoData,
+        viewModel = FakeForecastWeatherViewModel(
+            initialForecastWeatherInfoDataList = fakeForecastWeatherInfoDataList,
+        ),
     )
 }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -49,6 +49,18 @@ fun WeatherAppDetailContent(
     val fetching by viewModel.forecastFetching.collectAsStateWithLifecycle()
     val navController = rememberNavController()
 
+    fun showForecastWeatherFetchErrorDialog() {
+        navController.navigate(Route.WeatherDetail.ForecastWeatherFetchErrorDialog.name) {
+            launchSingleTop = true
+        }
+    }
+
+    fun fetchForecastWeather() {
+        viewModel.fetchForecastWeather {
+            showForecastWeatherFetchErrorDialog()
+        }
+    }
+
     NavHost(navController = navController, startDestination = Route.WeatherDetail.Main.name) {
         composable(Route.WeatherDetail.Main.name) {
             Column(
@@ -65,18 +77,14 @@ fun WeatherAppDetailContent(
                 onDismissRequest = { navController.popBackStack() },
                 onReload = {
                     navController.popBackStack()
-                    viewModel.fetchForecastWeather {
-                        navController.navigate(Route.WeatherDetail.ForecastWeatherFetchErrorDialog.name)
-                    }
+                    fetchForecastWeather()
                 },
             )
         }
     }
 
     DisposableEffect(LocalLifecycleOwner.current) {
-        viewModel.fetchForecastWeather {
-            navController.navigate(Route.WeatherDetail.ForecastWeatherFetchErrorDialog.name)
-        }
+        fetchForecastWeather()
         onDispose {
             viewModel.cancelFetchForecastWeather()
         }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/WeatherAppDetailContent.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -43,7 +42,7 @@ import java.time.format.DateTimeFormatter
 fun WeatherAppDetailContent(
     weatherInfoData: WeatherInfoData,
     modifier: Modifier = Modifier,
-    viewModel: ForecastWeatherViewModel = hiltViewModel(),
+    viewModel: ForecastWeatherViewModel,
 ) {
     val forecastWeatherInfoDataList by viewModel.forecastWeatherInfoDataList.collectAsStateWithLifecycle()
     val fetching by viewModel.forecastFetching.collectAsStateWithLifecycle()

--- a/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/model/WeatherInfoData.kt
@@ -13,8 +13,8 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import kotlin.math.roundToInt
 
-/** 仮天気情報
- * TODO:正式な形にする
+/** 天気情報
+ *
  */
 @Parcelize
 data class WeatherInfoData(

--- a/app/src/main/java/jp/co/yumemi/droidtraining/repository/FakeWeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/repository/FakeWeatherInfoDataRepository.kt
@@ -1,7 +1,6 @@
-package jp.co.yumemi.droidtraining.viewmodels
+package jp.co.yumemi.droidtraining.repository
 
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
-import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/jp/co/yumemi/droidtraining/usecases/GetForecastWeatherInfoDataListUseCase.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/usecases/GetForecastWeatherInfoDataListUseCase.kt
@@ -3,7 +3,7 @@ package jp.co.yumemi.droidtraining.usecases
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import javax.inject.Inject
 
-class GetForecastWeatherInfoDataUseCase @Inject constructor(
+class GetForecastWeatherInfoDataListUseCase @Inject constructor(
     private val weatherInfoDataRepository: WeatherInfoDataRepository,
 ) {
     operator fun invoke() = weatherInfoDataRepository.forecastWeatherInfoDataList

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeForecastWeatherViewModel.kt
@@ -1,6 +1,7 @@
 package jp.co.yumemi.droidtraining.viewmodels
 
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import jp.co.yumemi.droidtraining.repository.FakeWeatherInfoDataRepository
 import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeForecastWeatherViewModel.kt
@@ -1,0 +1,21 @@
+package jp.co.yumemi.droidtraining.viewmodels
+
+import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
+import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
+
+class FakeForecastWeatherViewModel(
+    initialForecastWeatherInfoDataList: List<WeatherInfoData> = listOf(),
+    updatedForecastWeatherInfoDataList: List<WeatherInfoData> = initialForecastWeatherInfoDataList,
+    fakeWeatherInfoDataRepository: FakeWeatherInfoDataRepository = FakeWeatherInfoDataRepository(
+        initialForecastWeatherInfoDataList = initialForecastWeatherInfoDataList,
+        updatedForecastWeatherInfoDataList = updatedForecastWeatherInfoDataList,
+    ),
+) : ForecastWeatherViewModel(
+    getForecastWeatherInfoDataListUseCase = GetForecastWeatherInfoDataListUseCase(
+        fakeWeatherInfoDataRepository,
+    ),
+    updateForecastWeatherInfoDataListUseCase = UpdateForecastWeatherInfoDataListUseCase(
+        fakeWeatherInfoDataRepository,
+    ),
+)

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeForecastWeatherViewModel.kt
@@ -2,13 +2,14 @@ package jp.co.yumemi.droidtraining.viewmodels
 
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.repository.FakeWeatherInfoDataRepository
+import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 
 class FakeForecastWeatherViewModel(
     initialForecastWeatherInfoDataList: List<WeatherInfoData> = listOf(),
     updatedForecastWeatherInfoDataList: List<WeatherInfoData> = initialForecastWeatherInfoDataList,
-    fakeWeatherInfoDataRepository: FakeWeatherInfoDataRepository = FakeWeatherInfoDataRepository(
+    fakeWeatherInfoDataRepository: WeatherInfoDataRepository = FakeWeatherInfoDataRepository(
         initialForecastWeatherInfoDataList = initialForecastWeatherInfoDataList,
         updatedForecastWeatherInfoDataList = updatedForecastWeatherInfoDataList,
     ),

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherInfoDataRepository.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherInfoDataRepository.kt
@@ -1,0 +1,35 @@
+package jp.co.yumemi.droidtraining.viewmodels
+
+import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeWeatherInfoDataRepository(
+    initialWeatherInfoData: WeatherInfoData? = null,
+    private val updatedWeatherInfoData: WeatherInfoData? = initialWeatherInfoData,
+    initialForecastWeatherInfoDataList: List<WeatherInfoData> = listOf(),
+    private val updatedForecastWeatherInfoDataList: List<WeatherInfoData> = initialForecastWeatherInfoDataList,
+) :
+    WeatherInfoDataRepository {
+    private val _weatherInfoData = MutableStateFlow(initialWeatherInfoData)
+    override val weatherInfoData: StateFlow<WeatherInfoData?>
+        get() = _weatherInfoData.asStateFlow()
+
+    private val _foreCastWeatherInfoDataList = MutableStateFlow(initialForecastWeatherInfoDataList)
+    override val forecastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
+        get() = _foreCastWeatherInfoDataList.asStateFlow()
+
+    override suspend fun updateWeatherInfoData() {
+        _weatherInfoData.value = updatedWeatherInfoData
+    }
+
+    override suspend fun updateForecastWeatherInfoDataList() {
+        _foreCastWeatherInfoDataList.value = updatedForecastWeatherInfoDataList
+    }
+
+    override fun setWeatherInfoData(weatherInfoData: WeatherInfoData) {
+        // do nothing
+    }
+}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
@@ -6,9 +6,6 @@ import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 // 以下はプレビュー用のフェイク（天気情報初期値を設定できる）
 class FakeWeatherMainViewModel(
@@ -32,29 +29,3 @@ class FakeWeatherMainViewModel(
         fakeWeatherInfoDataRepository,
     ),
 )
-
-class FakeWeatherInfoDataRepository(
-    private val initialWeatherInfoData: WeatherInfoData? = null,
-    private val updatedWeatherInfoData: WeatherInfoData? = initialWeatherInfoData,
-) :
-    WeatherInfoDataRepository {
-    private val _weatherInfoData = MutableStateFlow(initialWeatherInfoData)
-    override val weatherInfoData: StateFlow<WeatherInfoData?>
-        get() = _weatherInfoData.asStateFlow()
-
-    private val _foreCastWeatherInfoDataList = MutableStateFlow(listOf<WeatherInfoData>())
-    override val forecastWeatherInfoDataList: StateFlow<List<WeatherInfoData>>
-        get() = _foreCastWeatherInfoDataList.asStateFlow()
-
-    override suspend fun updateWeatherInfoData() {
-        _weatherInfoData.value = updatedWeatherInfoData
-    }
-
-    override suspend fun updateForecastWeatherInfoDataList() {
-        TODO("Not yet implemented")
-    }
-
-    override fun setWeatherInfoData(weatherInfoData: WeatherInfoData) {
-        // do nothing
-    }
-}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
@@ -1,6 +1,7 @@
 package jp.co.yumemi.droidtraining.viewmodels
 
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
+import jp.co.yumemi.droidtraining.repository.FakeWeatherInfoDataRepository
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
@@ -2,9 +2,7 @@ package jp.co.yumemi.droidtraining.viewmodels
 
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
-import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
-import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
 
 // 以下はプレビュー用のフェイク（天気情報初期値を設定できる）
@@ -20,12 +18,6 @@ class FakeWeatherMainViewModel(
         fakeWeatherInfoDataRepository,
     ),
     getWeatherInfoDataUseCase = GetWeatherInfoDataUseCase(
-        fakeWeatherInfoDataRepository,
-    ),
-    updateForecastWeatherInfoDataListUseCase = UpdateForecastWeatherInfoDataListUseCase(
-        fakeWeatherInfoDataRepository,
-    ),
-    getForecastWeatherInfoDataListUseCase = GetForecastWeatherInfoDataListUseCase(
         fakeWeatherInfoDataRepository,
     ),
 )

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.droidtraining
+package jp.co.yumemi.droidtraining.viewmodels
 
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/FakeWeatherMainViewModel.kt
@@ -2,7 +2,7 @@ package jp.co.yumemi.droidtraining.viewmodels
 
 import jp.co.yumemi.droidtraining.model.WeatherInfoData
 import jp.co.yumemi.droidtraining.repository.WeatherInfoDataRepository
-import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
@@ -28,7 +28,7 @@ class FakeWeatherMainViewModel(
     updateForecastWeatherInfoDataListUseCase = UpdateForecastWeatherInfoDataListUseCase(
         fakeWeatherInfoDataRepository,
     ),
-    getForecastWeatherInfoDataUseCase = GetForecastWeatherInfoDataUseCase(
+    getForecastWeatherInfoDataListUseCase = GetForecastWeatherInfoDataListUseCase(
         fakeWeatherInfoDataRepository,
     ),
 )

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.droidtraining
+package jp.co.yumemi.droidtraining.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
@@ -33,7 +33,6 @@ open class ForecastWeatherViewModel @Inject constructor(
                 onCancel = {},
             )
             _forecastFetching.value = false
-            onFailed()
         }
     }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
@@ -3,7 +3,7 @@ package jp.co.yumemi.droidtraining.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,11 +13,11 @@ import javax.inject.Inject
 
 @HiltViewModel
 open class ForecastWeatherViewModel @Inject constructor(
-    getForecastWeatherInfoDataUseCase: GetForecastWeatherInfoDataUseCase,
+    getForecastWeatherInfoDataListUseCase: GetForecastWeatherInfoDataListUseCase,
     private val updateForecastWeatherInfoDataListUseCase: UpdateForecastWeatherInfoDataListUseCase,
 ) : ViewModel() {
 
-    val forecastWeatherInfoDataList = getForecastWeatherInfoDataUseCase()
+    val forecastWeatherInfoDataList = getForecastWeatherInfoDataListUseCase()
     private val _forecastFetching = MutableStateFlow(false)
     val forecastFetching = _forecastFetching.asStateFlow()
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
@@ -33,6 +33,7 @@ open class ForecastWeatherViewModel @Inject constructor(
                 onCancel = {},
             )
             _forecastFetching.value = false
+            onFailed()
         }
     }
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/ForecastWeatherViewModel.kt
@@ -23,16 +23,14 @@ open class ForecastWeatherViewModel @Inject constructor(
 
     private var fetchForecastWeatherJob: Job? = null
 
-    open fun fetchForecastWeather(onFailed: () -> Unit, onCancel: () -> Unit = {}) {
+    open fun fetchForecastWeather(onFailed: () -> Unit) {
         fetchForecastWeatherJob = viewModelScope.launch {
             _forecastFetching.value = true
             updateForecastWeatherInfoDataListUseCase(
                 onFailed = {
                     onFailed()
                 },
-                onCancel = {
-                    onCancel()
-                },
+                onCancel = {},
             )
             _forecastFetching.value = false
         }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/WeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/WeatherMainViewModel.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.droidtraining
+package jp.co.yumemi.droidtraining.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/WeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/WeatherMainViewModel.kt
@@ -3,7 +3,7 @@ package jp.co.yumemi.droidtraining.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataUseCase
+import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
@@ -18,14 +18,14 @@ open class WeatherMainViewModel @Inject constructor(
     val updateWeatherInfoDataUseCase: UpdateWeatherInfoDataUseCase,
     val getWeatherInfoDataUseCase: GetWeatherInfoDataUseCase,
     val updateForecastWeatherInfoDataListUseCase: UpdateForecastWeatherInfoDataListUseCase,
-    val getForecastWeatherInfoDataUseCase: GetForecastWeatherInfoDataUseCase,
+    val getForecastWeatherInfoDataListUseCase: GetForecastWeatherInfoDataListUseCase,
 ) : ViewModel() {
 
     val weatherInfoData = getWeatherInfoDataUseCase()
     private val _updating = MutableStateFlow(false)
     val updating = _updating.asStateFlow()
 
-    val forecastWeatherInfoDataList = getForecastWeatherInfoDataUseCase()
+    val forecastWeatherInfoDataList = getForecastWeatherInfoDataListUseCase()
     private val _forecastFetching = MutableStateFlow(false)
     val forecastFetching = _forecastFetching.asStateFlow()
 

--- a/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/WeatherMainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/viewmodels/WeatherMainViewModel.kt
@@ -3,9 +3,7 @@ package jp.co.yumemi.droidtraining.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jp.co.yumemi.droidtraining.usecases.GetForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.GetWeatherInfoDataUseCase
-import jp.co.yumemi.droidtraining.usecases.UpdateForecastWeatherInfoDataListUseCase
 import jp.co.yumemi.droidtraining.usecases.UpdateWeatherInfoDataUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,20 +15,13 @@ import javax.inject.Inject
 open class WeatherMainViewModel @Inject constructor(
     val updateWeatherInfoDataUseCase: UpdateWeatherInfoDataUseCase,
     val getWeatherInfoDataUseCase: GetWeatherInfoDataUseCase,
-    val updateForecastWeatherInfoDataListUseCase: UpdateForecastWeatherInfoDataListUseCase,
-    val getForecastWeatherInfoDataListUseCase: GetForecastWeatherInfoDataListUseCase,
 ) : ViewModel() {
 
     val weatherInfoData = getWeatherInfoDataUseCase()
     private val _updating = MutableStateFlow(false)
     val updating = _updating.asStateFlow()
 
-    val forecastWeatherInfoDataList = getForecastWeatherInfoDataListUseCase()
-    private val _forecastFetching = MutableStateFlow(false)
-    val forecastFetching = _forecastFetching.asStateFlow()
-
     private var reloadWeatherJob: Job? = null
-    private var fetchForecastWeatherJob: Job? = null
 
     fun reloadWeather(onFailed: () -> Unit, onCancel: () -> Unit = {}) {
         reloadWeatherJob = viewModelScope.launch {
@@ -50,24 +41,5 @@ open class WeatherMainViewModel @Inject constructor(
 
     fun cancelReloadWeather() {
         reloadWeatherJob?.cancel()
-    }
-
-    fun fetchForecastWeather(onFailed: () -> Unit, onCancel: () -> Unit = {}) {
-        fetchForecastWeatherJob = viewModelScope.launch {
-            _forecastFetching.value = true
-            updateForecastWeatherInfoDataListUseCase(
-                onFailed = {
-                    onFailed()
-                },
-                onCancel = {
-                    onCancel()
-                },
-            )
-            _forecastFetching.value = false
-        }
-    }
-
-    fun cancelFetchForecastWeather() {
-        fetchForecastWeatherJob?.cancel()
     }
 }


### PR DESCRIPTION
## 修正内容
<!-- 
課題Issueの番号をここに記載してください。
PR画面では自動的にIssueへのURLリンクとなります。
同時にPRとIssueがリンクされ、PRがデフォルトブランチ(main)にマージされると自動でIssueもcloseされます。
参考：https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Resolve #80

- 詳細画面（予報画面）の状態をMainViewModel（メイン画面）に保持していたが、別ViewModelで定義
- 伴ってテスト・プレビュー関連修正（Fakeなど）


## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [ ] ぱっとみて違和感がないかチェックしてApproveする
- [x] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
<!--
レビューアに確認してほしい事柄の記載をお願い致します。
特に、本PRにてレビュー対象外の内容があれば合わせて記載をお願い致します。

(例)
* ビルドが通る状態となっているか
* warnings が出力されないこと
* デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
* このコミット xxxxxxxxx(commit hash) を主にレビューして欲しい
-->
複数ViewModelをComposeで使用したのは初めてなのでそのあたりの使い方を確認していただけると嬉しいです


## スクリーンショット
変更なし

## 備考
